### PR TITLE
fix: Update for compatibilty with SILE 0.14.11 and resilient 2.2

### DIFF
--- a/classes/teibook.lua
+++ b/classes/teibook.lua
@@ -219,8 +219,14 @@ function class:_init (options)
 
 
   local styles = self.packages["resilient.styles"]
-  styles:defineStyle("teibook:titlepage", {}, { font = { family = "Libertinus Sans", size = "20pt" } })
-  styles:defineStyle("teibook:impressum", {}, { font = { style = "italic", features = "+hlig,+salt" } })
+  styles:defineStyle("teibook:titlepage", {}, {
+    font = { family = "Libertinus Sans", size = "20pt" },
+    paragraph = { align = "right" },
+  })
+  styles:defineStyle("teibook:impressum", {}, {
+    font = { style = "italic", features = "+hlig,+salt" },
+    paragraph = { align = "center" },
+  })
 end
 
 function class:endPage ()
@@ -322,12 +328,7 @@ function class:registerCommands ()
     SILE.call("nofolios")
     SILE.call("hbox", {}, {})
     SILE.call("vfill")
-    SILE.call("style:apply", { name = "teibook:titlepage" }, function ()
-      SILE.call("raggedleft", {}, function()
-        SILE.process(content)
-        SILE.typesetter:leaveHmode()
-      end)
-    end)
+    SILE.call("style:apply:paragraph", { name = "teibook:titlepage" }, content)
     SILE.call("vfill")
     SILE.call("hbox", {}, {})
     SILE.call("eject")
@@ -382,11 +383,7 @@ function class:registerCommands ()
     SILE.call("hbox", {}, {})
     SILE.call("vfill")
     SILE.typesetter:leaveHmode()
-    SILE.call("style:apply", { name = "teibook:impressum" }, function ()
-      SILE.call("center", {}, function()
-        SILE.process(content)
-      end)
-    end)
+    SILE.call("style:apply:paragraph", { name = "teibook:impressum" }, content)
     SILE.call("hbox", {}, {})
     SILE.typesetter:leaveHmode()
     SILE.call("break")

--- a/packages/teiabbr/init.lua
+++ b/packages/teiabbr/init.lua
@@ -88,8 +88,9 @@ function package:writeAbbr ()
   table.sort(a, compare)
 
   SILE.settings:temporarily(function ()
-    SILE.settings:set("document.lskip", "2cm")
-    SILE.settings:set("document.parindent", "-2cm")
+    local indent = SILE.length("2cm")
+    SILE.settings:set("document.lskip", indent)
+    SILE.settings:set("document.parindent", indent:negate())
     SILE.call("medskip")
     SILE.call("pdf:destination", { name = "tei_abbreviations" })
     SILE.call("pdf:bookmark", { title = teitrans.titles.abbreviations, dest = "tei_abbreviations", level = 1 })
@@ -98,8 +99,14 @@ function package:writeAbbr ()
 
     for _, v in pairs(teitrans.symbols) do
       if v.used then
-        local h = SILE.call("hbox", {}, { v.symbol })
-        h.width = SILE.length("0cm") -- Real weird but works.
+        local h = SILE.typesetter:makeHbox({ v.symbol })
+        SILE.typesetter:pushHbox(h)
+        local offset = indent:absolute() - h.width
+        if offset:tonumber() > 0 then
+          SILE.call("kern", { width = offset })
+        else
+          SILE.typesetter:typeset(" ")
+        end
         SILE.typesetter:typeset(v.full)
         SILE.typesetter:leaveHmode()
       end
@@ -108,7 +115,12 @@ function package:writeAbbr ()
       local h = SILE.call("hbox", {}, function ()
         SILE.call("style:apply", { name = "tei:pos" }, { n.translate })
       end)
-      h.width = SILE.length("0cm") -- Real weird but works.
+      local offset = indent:absolute() - h.width
+      if offset:tonumber() > 0 then
+        SILE.call("kern", { width = offset })
+      else
+        SILE.typesetter:typeset(" ")
+      end
       SILE.typesetter:typeset(n.full)
       SILE.typesetter:leaveHmode()
     end
@@ -125,8 +137,9 @@ function package.writeBibl (_, bibliography)
   end
 
   SILE.settings:temporarily(function ()
-    SILE.settings:set("document.lskip", "1cm")
-    SILE.settings:set("document.parindent", "-1cm")
+    local indent = SILE.length("1cm")
+    SILE.settings:set("document.lskip", indent)
+    SILE.settings:set("document.parindent", indent:negate())
     SILE.call("medskip")
     SILE.call("pdf:destination", { name = "tei_bibliography" })
     SILE.call("pdf:bookmark", { title = teitrans.titles.references, dest = "tei_bibliography", level = 1 })
@@ -143,8 +156,9 @@ function package.writeBibl (_, bibliography)
             bibliography[i].options.n or "["..nBibl.."]"
           })
         end)
-        if h.width < 0 then
-          h.width = SILE.length("0cm") -- Real weird but works.
+        local offset = indent:absolute() - h.width
+        if offset:tonumber() > 0 then
+          SILE.call("kern", { width = offset })
         else
           SILE.typesetter:typeset(" ")
         end


### PR DESCRIPTION
- SILE 0.14.9 fixed a parindent issue which we had avoided by mere luck, but we need to do the proper computation now in the abbreviation and bibliography section.
- resilient 2.2 deprecated using functional calls in styles, preferring an AST structure.